### PR TITLE
Fix bug with job directory and change defaults for creating pools

### DIFF
--- a/toolbox/batchCreateJob.m
+++ b/toolbox/batchCreateJob.m
@@ -8,7 +8,7 @@ config = getBatchConfigs();
 batchLib = getBatchLib();
 
 % Copy job data to Azure Storage
-batchLib.CopyJobDataToShare(job.Username, cluster.JobStorageLocation, props.JobLocation, job.Name);
+batchLib.CopyJobDataToShare(job.Username, cluster.JobStorageLocation, props.JobLocation);
 fprintf('Job data uploaded to share\n');
 
 % Create the job

--- a/toolbox/batchCreatePool.m
+++ b/toolbox/batchCreatePool.m
@@ -10,12 +10,15 @@ function batchCreatePool(poolId, numberOfComputeNodes, vmSize, interComputeNodeC
 %   Azure VM sizes can be found here:
 %   https://azure.microsoft.com/en-us/documentation/articles/cloud-services-sizes-specs/
 % interComputeNodeCommunicationEnabled: boolean. Whether to enable direct
-%   communication between the nodes in the pool. For communicating jobs, you
-%   must pass in true.
+%   communication between the nodes in the pool. To support communicating
+%   jobs with this Batch pool, you must pass in true.
 % Optional params:
-% maxTasksPerComputeNode : integer. If none specified, will default to the
-%   number of cores on the specified VM size. For communicating jobs, you
-%   must specify a value of 1.
+% maxTasksPerComputeNode : integer. The maximum number of tasks to schedule
+%   against a Batch compute node. For communicating jobs, this value must
+%   be 1. If no value is specified and interComputeNodeCommunicationEnabled
+%   is true, then a default value of 1 will be used. If no value is
+%   specified and interComputeNodeCommunicationEnabled is false, then the
+%   value will be set to the number of cores on the specified VM size.
 
 p = inputParser();
 p.addRequired('poolId');
@@ -30,19 +33,28 @@ batchLib = getBatchLib();
 if isnumeric(p.Results.maxTasksPerComputeNode)
     % Use the user specified value
     maxTasksPerComputeNode = p.Results.maxTasksPerComputeNode;
+    
+    % For a communicating job, this must be set to 1.
+    if interComputeNodeCommunicationEnabled && maxTasksPerComputeNode ~= 1
+        error('When interComputeNodeCommunicationEnabled is set to true, maxTasksPerComputeNode must be set to 1');
+    end
 else
-   % Default to the core count on the specified VM size. 
-   vmSizeCoreCountMap = getAzureVmSizeCoreCountMap();
+    if interComputeNodeCommunicationEnabled
+        % For a communicating job, this must be set to 1.
+        maxTasksPerComputeNode = 1; 
+    else   
+        % Default to the core count on the specified VM size. 
+        vmSizeCoreCountMap = getAzureVmSizeCoreCountMap();
    
-   vmSizeLower = lower(p.Results.vmSize);
-   if vmSizeCoreCountMap.isKey(vmSizeLower)
-       maxTasksPerComputeNode = vmSizeCoreCountMap(vmSizeLower);
-   else
-       % This default value is in case the specified VM size is not recognized
-       % (ex: the mapping table is out of date).
-       maxTasksPerComputeNode = 4;
-   end
-   
+        vmSizeLower = lower(p.Results.vmSize);
+        if vmSizeCoreCountMap.isKey(vmSizeLower)
+            maxTasksPerComputeNode = vmSizeCoreCountMap(vmSizeLower);
+        else
+            % This default value is in case the specified VM size is not recognized
+            % (ex: the mapping table is out of date).
+            maxTasksPerComputeNode = 4;
+        end
+    end
 end
 
 batchLib.CreatePool(p.Results.poolId, p.Results.vmSize, p.Results.numberOfComputeNodes, ...

--- a/toolbox/batchDeleteJobFcn.m
+++ b/toolbox/batchDeleteJobFcn.m
@@ -22,7 +22,7 @@ if isempty(data)
 end
 
 batchLib = getBatchLib();
-batchLib.DeleteJob(data.BatchClusterJobId, job.Name, job.Username, data.JobLocation);
+batchLib.DeleteJob(data.BatchClusterJobId, job.Username, data.JobLocation);
 
 end
 

--- a/toolbox/batchGetJobStateFcn.m
+++ b/toolbox/batchGetJobStateFcn.m
@@ -40,7 +40,7 @@ if strcmpi(jobState, 'finished')
     
     % Because of the short circuit before the .NET call above, we should avoid redundant downloads.
     fprintf('Downloading job data...\n');
-    batchLib.CopyJobDataFromShare(job.Username, cluster.JobStorageLocation, data.JobLocation, job.Name);
+    batchLib.CopyJobDataFromShare(job.Username, cluster.JobStorageLocation, data.JobLocation);
     fprintf('Downloaded job data from share.\n');
 end
 


### PR DESCRIPTION
- Fix bug where the job name was used instead of its directory
- Update the default maxTasksPerNode value when creating pools based on whether communicating jobs will be supported
